### PR TITLE
InAppBrowser Compatibility

### DIFF
--- a/src/ios/CDVPassbook.m
+++ b/src/ios/CDVPassbook.m
@@ -56,12 +56,20 @@
     }
     
     PKAddPassesViewController *c = [[PKAddPassesViewController alloc] initWithPass:pass];
-    
-    [self.viewController presentViewController:c animated:YES completion:^{
+   
+    [[self getTopMostViewController] presentViewController:c animated:YES completion:^{
         if(successBlock) {
             successBlock();
         }
     }];
+}
+
+- (UIViewController*) getTopMostViewController {
+    UIViewController *presentingViewController = [[[UIApplication sharedApplication] delegate] window].rootViewController;
+    while (presentingViewController.presentedViewController != nil) {
+        presentingViewController = presentingViewController.presentedViewController;
+    }
+    return presentingViewController;
 }
 
 - (void)downloadPass:(NSURL*) url success:(void (^)(void))successBlock error:(void (^)(NSError *error))errorBlock


### PR DESCRIPTION
The plugin does not work correctly when using the InAppBrowser. If an InAppBrowser windows is open, it tries to present itself to the Main window, which is not the top most window.
This fix searches for the topmost window and presents the PassBook plugin to that, so it appears on top of the InAppBrowser.