### PR TITLE
get the real top most view controller

### DIFF
--- a/src/ios/CDVPassbook.m
+++ b/src/ios/CDVPassbook.m
@@ -202,7 +202,7 @@ typedef void (^AddPassResultBlock)(PKPass *pass, BOOL added);
 }
 
 - (UIViewController*) getTopMostViewController {
-    UIViewController *presentingViewController = [[[UIApplication sharedApplication] delegate] window].rootViewController;
+    UIViewController *presentingViewController = [[UIApplication sharedApplication] keyWindow].rootViewController;
     while (presentingViewController.presentedViewController != nil) {
         presentingViewController = presentingViewController.presentedViewController;
     }


### PR DESCRIPTION
Hi !

By using cordova and InAppBrowser and making both communicate to use this plugin we had a issue of the wallet window hiding behind InAppBrowser. The fix here is to simply using keyWindow to get the "real" top most viewController in the appropriate function !

I've had the exact similar problem and similar fix with another cordova plugin about social sharing, it seems to be a pretty common error easily fixed :-)