### PR TITLE
Multi-pass support and automatic WKWebView handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# com.passslot.cordova.plugin.passbook
+# cordova-plugin-passbook
 
 This plugin provides support for showing Passbook passs to your users and allows them to add it to their native Wallet (regardless of how you create your passes, whether you do it on your own or using any third-party services like [PassSlot](http://www.PassSlot.com))
 
@@ -14,9 +14,7 @@ Or the latest (unstable) version:
 
 ## Supported Platforms
 
-
 - iOS
-- ~~Android~~ (coming soon)
 
 ## Example
 
@@ -25,9 +23,7 @@ Or the latest (unstable) version:
 ```javascript
     Passbook.downloadPass('https://d.pslot.io/cQY2f', function (pass, added) {
         console.log(pass, added);
-        if (added) {
-            Passbook.openPass(pass);
-        } else {
+        if (!added) {
             alert('Please add the pass');
         }
     }, function (error) {
@@ -46,10 +42,37 @@ Or the latest (unstable) version:
 
     Passbook.downloadPass(callData, function (pass, added) {
         console.log(pass, added);
-        if (added) {
-            Passbook.openPass(pass);
-        } else {
+        if (!added) {
             alert('Please add the pass');
+        }
+    }, function (error) {
+        console.error(error);
+    });
+```
+
+### Multiple passes
+
+```javascript
+ Passbook.downloadPasses(['https://d.pslot.io/cQY2f', 'https://d.pslot.io/AeY3D'], function (passes, added) {
+        console.log(passes, added);
+        if (!added) {
+            alert('Please add the passes');
+        }
+    }, function (error) {
+        console.error(error);
+    });
+```
+
+### Multiple passes with headers
+
+```javascript
+ Passbook.downloadPasses({
+    urls: ['https://d.pslot.io/cQY2f', 'https://d.pslot.io/AeY3D'],
+    headers: {authorization: "Bearer <token>"}
+ }, function (passes, added) {
+        console.log(passes, added);
+        if (!added) {
+            alert('Please add the passes');
         }
     }, function (error) {
         console.error(error);

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,4 +1,4 @@
-# com.passslot.cordova.plugin.passbook
+# cordova-plugin-passbook
 
 This plugin provides basic support for Passbook on iOS.
 It allows you to show Passbook passes so that your users can add them directly to Passbook.
@@ -7,7 +7,7 @@ On cordova >= 3.1.0, this plugin registers for .pkpass URLs and automatically do
 
 ## Installation
 
-    cordova plugin add com.passslot.cordova.plugin.passbook
+    cordova plugin add cordova-plugin-passbook
 
 ## Supported Platforms
 
@@ -31,26 +31,25 @@ Returns if Passbook is available on the current device to the `resultCallback` c
 
 
 ### Example
+```javascript
+// onSuccess Callback
+// This method accepts a boolean, which specified if Passbook is available
+//
+var onResult = function(isAvailable) {
+    if(!isAvailable) {
+        alert('Passbook is not available');
+    }
+};
 
-    // onSuccess Callback
-    // This method accepts a boolean, which specified if Passbook is available
-    //
-    var onResult = function(isAvailable) {
-    	if(!isAvailable) {
-    		alert('Passbook is not available');
-    	}
-    };
-
-   	Passbook.available(onResult);
-
+Passbook.available(onResult);
+```
 ## Passbook.downloadPass
 
 Downloads a pass from a the provided URL and shows it to the user.
 When the pass was successfully downloaded and was shown to the user, and the user either canceld or added the pass, the `passCallback` callback executes. If there is an error, the `errorCallback` callback executes with an error string as the parameter
-
-    Passbook.downloadPass(callData,
-                         [passCallback],
-                         [errorCallback]);
+```javascript
+Passbook.downloadPass(callData, [passCallback], [errorCallback]);
+```
 
 ### Parameters
 
@@ -64,19 +63,19 @@ When the pass was successfully downloaded and was shown to the user, and the use
 ### Simple Example
 
 ```javascript
-    // onSuccess Callback
-    function onSuccess(pass, added) {
-        console.log('Pass shown to the user');
-        console.log(pass, added);
-    }
+// onSuccess Callback
+function onSuccess(pass, added) {
+    console.log('Pass shown to the user');
+    console.log(pass, added);
+}
 
-    // onError Callback receives a string with the error message
-    //
-    function onError(error) {
-    	alert('Could now show pass: ' + error);
-    }
+// onError Callback receives a string with the error message
+//
+function onError(error) {
+    alert('Could now show pass: ' + error);
+}
 
-    Passbook.downloadPass('https://d.pslot.io/cQY2f', onSuccess, onError);
+Passbook.downloadPass('https://d.pslot.io/cQY2f', onSuccess, onError);
 ```
 
 ### Adding Header
@@ -99,22 +98,73 @@ var callData =  {
                  "headers":{ "authorization": "Bearer <token>" }
                };
 Passbook.downloadPass(callData, onSuccess, onError);
+```
 
+## Passbook.downloadPasses
 
+Downloads a list of passes from a the provided URLs and shows them to the user.
+When the passes are successfully downloaded, shown to the user, and the user either cancelled or added the pass, the `passCallback` callback executes passing an array of passes and a boolean of value of if they were added or not. If there is an error, the `errorCallback` callback executes with an error string as the parameter
+```javascript
+Passbook.downloadPasses(callData, [passCallback], [errorCallback]);
+```
+### Parameters
+
+- __callData__: It could be either an array of URL strings or an Object in the form `{ urls:[<url1>,<url2>], headers?:<{}> }` .
+
+- __passCallback__: (Optional) The callback that executes when the pass is shown to the user. Returns the downloaded pass (passTypeIdentifier, serialNumber, passURL) and if it was added to Passbook.
+
+- __errorCallback__: (Optional) The callback that executes if an error occurs, e.g if Passbook is not available, the URL is invalid or no valid pass was found at the given URL.
+
+### Simple Example
+
+```javascript
+// onSuccess Callback
+function onSuccess(passes, added) {
+    console.log('Passes shown to the user');
+    console.log(passes, added);
+}
+
+// onError Callback receives a string with the error message
+//
+function onError(error) {
+    alert('Could now show passes: ' + error);
+}
+
+Passbook.downloadPasses(['https://d.pslot.io/cQY2f', 'https://d.pslot.io/DbM3E'], onSuccess, onError);
+```
+
+### Adding Header
+
+```javascript
+// onSuccess Callback
+function onSuccess(passes, added) {
+    console.log('Pass shown to the user');
+    console.log(passes, added);
+}
+
+// onError Callback receives a string with the error message
+//
+function onError(error) {
+  alert('Could now show passes: ' + error);
+}
+
+var callData =  {
+                 "urls":['https://d.pslot.io/cQY2f', 'https://d.pslot.io/DbM3E'],
+                 "headers":{ "authorization": "Bearer <token>" }
+               };
+Passbook.downloadPasses(callData, onSuccess, onError);
 ```
 
 ## Passbook.addPass
 
 Add a pass from a the provided local file and shows it to the user.
 When the pass was successfully shown to the user, and the user either canceled or added the pass, the `passCallback` callback executes. If there is an error, the `errorCallback` callback executes with an error string as the parameter
-
-    Passbook.addPass(file,
-                         [passCallback],
-                         [errorCallback]);
-
+```javascript
+Passbook.addPass(file, [passCallback], [errorCallback]);
+```
 ### Parameters
 
-- __file__: The file of the pass that should be downloaded. (e.g. file:///..../sample.pkpass)
+- __file__: The file of the pass that should be shown. (e.g. file:///..../sample.pkpass)
 
 - __passCallback__: (Optional) The callback that executes when the pass is shown to the user. Returns the local pass (passTypeIdentifier, serialNumber, passURL) and if it was added to Passbook.
 
@@ -122,17 +172,57 @@ When the pass was successfully shown to the user, and the user either canceled o
 
 
 ### Example
+```javascript
+// onSuccess Callback
+function onSuccess(pass, added) {
+    console.log('Pass shown to the user');
+    console.log(pass, added);
+}
 
-    // onSuccess Callback
-    function onSuccess(pass, added) {
-        console.log('Pass shown to the user');
-        console.log(pass, added);
-    }
+// onError Callback receives a string with the error message
+//
+function onError(error) {
+    alert('Could now show pass: ' + error);
+}
 
-    // onError Callback receives a string with the error message
-    //
-    function onError(error) {
-    	alert('Could now show pass: ' + error);
-    }
+Passbook.addPass(cordova.file.applicationDirectory + 'sample.pkpass', onSuccess, onError);
+```
+## Passbook.addPasses
 
-    Passbook.addPass(cordova.file.applicationDirectory + 'sample.pkpass', onSuccess, onError);
+Add a list of passes from a the provided local files and shows it to the user.
+When the passes are successfully shown to the user, and the user either cancelled or added the passes, the `passCallback` callback executes. If there is an error, the `errorCallback` callback executes with an error string as the parameter
+```javascript
+Passbook.addPass(files, [passCallback], [errorCallback]);
+```
+### Parameters
+
+- __files__: The files of the passes that should be shown. (e.g. ["file:///..../sample1.pkpass","file:///..../sample2.pkpass"])
+
+- __passCallback__: (Optional) The callback that executes when the pass is shown to the user. Returns the local pass (passTypeIdentifier, serialNumber, passURL) and if it was added to Passbook.
+
+- __errorCallback__: (Optional) The callback that executes if an error occurs, e.g if Passbook is not available, the URL is invalid or no valid pass was found at the given URL.
+
+
+### Example
+```javascript
+// onSuccess Callback
+function onSuccess(passes, added) {
+    console.log('Passes shown to the user');
+    console.log(passes, added);
+}
+
+// onError Callback receives a string with the error message
+//
+function onError(error) {
+    alert('Could now show pass: ' + error);
+}
+
+Passbook.addPasses(
+    [
+        cordova.file.applicationDirectory + 'sample1.pkpass', 
+        cordova.file.applicationDirectory + 'sample2.pkpass'
+    ], 
+    onSuccess, 
+    onError
+);
+```

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,10 +2,10 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-passbook"
-      version="0.2.1">
+      version="0.3.0">
 
     <name>Passbook</name>
-    <description>This plugin allows you to add passes to Passbook</description>
+    <description>This plugin allows you to add passes to iOS Wallet</description>
     <author>PassSlot.com</author>
     <license>Apache 2.0</license>
     <engines>
@@ -31,5 +31,16 @@
         <framework src="PassKit.framework" />
 
     </platform>
-
+    
+    <config-file target="*-Debug.plist" parent="com.apple.developer.pass-type-identifiers">
+        <array>
+            <string>$(TeamIdentifierPrefix)*</string>
+        </array>
+    </config-file>
+    <config-file target="*-Release.plist" parent="com.apple.developer.pass-type-identifiers">
+        <array>
+            <string>$(TeamIdentifierPrefix)*</string>
+        </array>
+    </config-file>
+    
 </plugin>

--- a/src/ios/CDVPassbook.h
+++ b/src/ios/CDVPassbook.h
@@ -4,7 +4,8 @@
 
 - (void)available:(CDVInvokedUrlCommand*)command;
 - (void)downloadPass:(CDVInvokedUrlCommand*)command;
+- (void)downloadPasses:(CDVInvokedUrlCommand*)command;
 - (void)addPass:(CDVInvokedUrlCommand*)command;
+- (void)addPasses:(CDVInvokedUrlCommand*)command;
 - (void)openPass:(CDVInvokedUrlCommand*)command;
-
 @end

--- a/www/passbook.js
+++ b/www/passbook.js
@@ -16,6 +16,17 @@ var Pass = function (passTypeIdentifier, serialNumber, passURL) {
     this.passURL = passURL || null;
 };
 
+function toPass(pass) {
+    return new Pass(pass.passTypeIdentifier, pass.serialNumber, pass.passURL)
+}
+
+function toPassArray(passes) {
+    var result = [];
+    for (var index = 0; index < passes.length; index++) {
+        result.push(toPass(passes[index]));
+    }
+    return result;
+}
 
 Pass.prototype.open = function () {
     passbook.openPass(this.passURL, null, null);
@@ -40,14 +51,30 @@ passbook.downloadPass = function (callData, passCallback, errorCallback) {
     exec(function (result) {
         if (typeof(passCallback) === 'function') {
             var pass = result.pass;
-            passCallback(new Pass(pass.passTypeIdentifier, pass.serialNumber, pass.passURL), result.added);
+            passCallback(toPass(pass), result.added);
         }
     }, errorCallback, "Passbook", "downloadPass", [callData]);
 };
 
 /**
  *
- * @param file Local File URL, e.g. file:///path/pass.pkpass
+ * @param {(string[]|{urls: string[], headers?: Object})}  callData
+ * @param {Function} passCallback
+ * @param {Function} errorCallback
+ */
+passbook.downloadPasses = function (callData, passCallback, errorCallback) {
+    exec(function (result) {
+        if (typeof(passCallback) === 'function') {
+            var passes = result.passes;
+            passCallback(toPassArray(passes), result.added);
+        }
+    }, errorCallback, "Passbook", "downloadPasses", [callData]);
+};
+               
+
+/**
+ *
+ * @param {string} file Local File URL, e.g. file:///path/pass.pkpass
  * @param {Function} passCallback
  * @param {Function} errorCallback
  */
@@ -55,11 +82,26 @@ passbook.addPass = function (file, passCallback, errorCallback) {
     exec(function (result) {
         if (typeof(passCallback) === 'function') {
             var pass = result.pass;
-            passCallback(new Pass(pass.passTypeIdentifier, pass.serialNumber, pass.passURL), result.added);
+            passCallback(toPass(pass), result.added);
         }
     }, errorCallback, "Passbook", "addPass", [file]);
 };
 
+/**
+ *
+ * @param {string[]} files array of Local File URLs, e.g. file:///path/pass.pkpass
+ * @param {Function} passCallback
+ * @param {Function} errorCallback
+ */
+passbook.addPasses = function (file, passCallback, errorCallback) {
+    exec(function (result) {
+        if (typeof(passCallback) === 'function') {
+            var passes = result.passes;
+            passCallback(toPassArray(passes), result.added);
+        }
+    }, errorCallback, "Passbook", "addPasses", [file]);
+};
+               
 /**
  *
  * @param {Pass|string} passOrUrl


### PR DESCRIPTION
This update removes all usage of deprecated APIs from the library. Specifically NSURLRequest has now been replaced with NSURLSession related functionality.

Additionally the plugin has been updated to support automatic handling of ".pkpass" URL links within Cordova when using the WKWebViewEngine (the default and required engine for App Store submissions). A URL click within the Cordova Web View on a .pkpass file will now properly download the pass and present it to the user as if it was in the application.

There is now a "downloadPasses" function that accepts an array of URLs (or an object with a "urls" array property and a "headers" object property), downloads the given packages (in parallel in memory) and presents them in a single approval view. The success callback then has an array of passes as the first argument (instead of a single pass)

There is also an equivalent "addPasses" function that accepts an array of files and presents them in a single approval view that also calls the success callback with an array of a passes.